### PR TITLE
Make firstName optional

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Person.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Person.java
@@ -28,7 +28,6 @@ import javax.validation.constraints.NotEmpty;
 public class Person extends BaseEntity {
 
     @Column(name = "first_name")
-    @NotEmpty
     private String firstName;
 
     @Column(name = "last_name")
@@ -49,6 +48,13 @@ public class Person extends BaseEntity {
 
     public void setLastName(String lastName) {
         this.lastName = lastName;
+    }
+
+    public String getFullName() {
+        if (this.firstName == null || this.firstName.equals("")) {
+            return this.lastName;
+        }
+        return this.firstName + " " + this.lastName;
     }
 
 }

--- a/src/main/resources/templates/owners/ownerDetails.html
+++ b/src/main/resources/templates/owners/ownerDetails.html
@@ -12,7 +12,7 @@
     <table class="table table-striped" th:object="${owner}">
       <tr>
         <th>Name</th>
-        <td><b th:text="*{firstName + ' ' + lastName}"></b></td>
+        <td><b th:text="*{fullName}"></b></td>
       </tr>
       <tr>
         <th>Address</th>

--- a/src/main/resources/templates/owners/ownersList.html
+++ b/src/main/resources/templates/owners/ownersList.html
@@ -19,7 +19,7 @@
         <tbody>
           <tr th:each="owner : ${selections}">
               <td>
-                  <a th:href="@{/owners/__${owner.id}__}" th:text="${owner.firstName + ' ' + owner.lastName}"/></a>
+                  <a th:href="@{/owners/__${owner.id}__}" th:text="${owner.fullName}"/></a>
               </td>
               <td th:text="${owner.address}"/>
               <td th:text="${owner.city}"/>

--- a/src/main/resources/templates/pets/createOrUpdatePetForm.html
+++ b/src/main/resources/templates/pets/createOrUpdatePetForm.html
@@ -13,7 +13,7 @@
       <div class="form-group">
         <label class="col-sm-2 control-label">Owner</label>
         <div class="col-sm-10">
-          <span th:text="${pet.owner?.firstName + ' ' + pet.owner?.lastName}" />
+          <span th:text="${pet.owner?.fullName}" />
         </div>
       </div>
       <input

--- a/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/model/ValidatorTests.java
@@ -42,7 +42,7 @@ public class ValidatorTests {
     }
 
     @Test
-    public void shouldNotValidateWhenFirstNameEmpty() {
+    public void shouldValidateWhenFirstNameEmpty() {
 
         LocaleContextHolder.setLocale(Locale.ENGLISH);
         Person person = new Person();
@@ -53,10 +53,7 @@ public class ValidatorTests {
         Set<ConstraintViolation<Person>> constraintViolations = validator
                 .validate(person);
 
-        assertThat(constraintViolations).hasSize(1);
-        ConstraintViolation<Person> violation = constraintViolations.iterator().next();
-        assertThat(violation.getPropertyPath().toString()).isEqualTo("firstName");
-        assertThat(violation.getMessage()).isEqualTo("must not be empty");
+        assertThat(constraintViolations).hasSize(0);
     }
 
 }


### PR DESCRIPTION
This PR makes the owner's `firstName` optional
and introduces a derived property `fullName` that
handles the possibly absense of the `firstName`.

Fixes gitpod-io/spring-petclinic#7