### PR TITLE
enable IntelliJ warm up in init task

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,13 @@
 
 tasks:
+- init: |
+    mkdir /tmp/backend && cd /tmp/backend
+    curl -sSLo backend.tar.gz "https://download.jetbrains.com/idea/ideaIU-2021.3.2.tar.gz" && tar -xf backend.tar.gz --strip-components=1 && rm backend.tar.gz
+    printf '\nshared.indexes.download.auto.consent=true' >> "/tmp/backend/bin/idea.properties"
+    unset JAVA_TOOL_OPTIONS
+    export IJ_HOST_CONFIG_BASE_DIR=/workspace/.config/JetBrains
+    export IJ_HOST_SYSTEM_BASE_DIR=/workspace/.cache/JetBrains
+    /tmp/backend/bin/remote-dev-server.sh warmup "$GITPOD_REPO_ROOT"
 - init: ./mvnw package -DskipTests
   command: java -jar target/*.jar
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,13 +2,19 @@
 tasks:
 - init: |
     if [ ! "$GITPOD_HEADLESS" = "true" ] ; then exit ; fi
+    curl https://raw.githubusercontent.com/gitpod-io/gitpod/main/WORKSPACE.yaml > /tmp/gitpod_workspace.yaml
+    sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+    sudo chmod a+x /usr/local/bin/yq
+    INTELLIJ_DOWNLOAD_URL=$(yq eval '.defaultArgs.intellijDownloadUrl' /tmp/gitpod_workspace.yaml)
+    echo $INTELLIJ_DOWNLOAD_URL
     mkdir /tmp/backend && cd /tmp/backend
-    curl -sSLo backend.tar.gz "https://download.jetbrains.com/idea/ideaIU-2021.3.2.tar.gz" && tar -xf backend.tar.gz --strip-components=1 && rm backend.tar.gz
+    curl -sSLo backend.tar.gz "$INTELLIJ_DOWNLOAD_URL" && tar -xf backend.tar.gz --strip-components=1 && rm backend.tar.gz
     printf '\nshared.indexes.download.auto.consent=true' >> "/tmp/backend/bin/idea.properties"
     unset JAVA_TOOL_OPTIONS
     export IJ_HOST_CONFIG_BASE_DIR=/workspace/.config/JetBrains
     export IJ_HOST_SYSTEM_BASE_DIR=/workspace/.cache/JetBrains
     /tmp/backend/bin/remote-dev-server.sh warmup "$GITPOD_REPO_ROOT"
+  name: IntellIJ warm up
 - init: ./mvnw package -DskipTests
   command: java -jar target/*.jar
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,7 @@
 
 tasks:
 - init: |
+    if [ ! "$GITPOD_HEADLESS" = "true" ] ; then exit ; fi
     mkdir /tmp/backend && cd /tmp/backend
     curl -sSLo backend.tar.gz "https://download.jetbrains.com/idea/ideaIU-2021.3.2.tar.gz" && tar -xf backend.tar.gz --strip-components=1 && rm backend.tar.gz
     printf '\nshared.indexes.download.auto.consent=true' >> "/tmp/backend/bin/idea.properties"

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,9 @@
 
     <jacoco.version>0.8.2</jacoco.version>
 
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Enable IntelliJ in [preferences](https://gitpod.io/preferences).
- [Start a workspace for this branch](https://gitpod.io/#https://github.com/gitpod-io/spring-petclinic/pull/55), wait for the prebuild and check that smartness is available immediately.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
