### PR TITLE
Add preview springboot profile & set as default gitpod init task

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,10 @@
 tasks:
 - init: ./mvnw package -DskipTests
-  command: java -jar target/*.jar
+  command: java -jar -Dspring.profiles.active=preview target/*.jar
 
 # exposed ports
 ports:
-- port: 8080
+- port: 8090
   onOpen: open-preview
 
 vscode:

--- a/src/main/resources/application-preview.properties
+++ b/src/main/resources/application-preview.properties
@@ -1,0 +1,2 @@
+# used for .gitpod.yml init task
+server.port=8090


### PR DESCRIPTION
## Description

Since Gitpod init task starts the application server in "preview mode", it might be reasonable to specify a different port for preview, and left the default port for IDE runConfiguration (vscode/open-vsc/IDEA), which avoids port conflict and encourage Java developers to actually "run" the application on the cloud and learn Gitpod workspace.

## Related Issue(s)

Fixes #56 

## How to test

1. Start a Gitpod workspace from <https://gitpod.io/#https://github.com/yaohui-wyh/spring-petclinic>
2. When init task finished, application starts at port 8090 successfully embedded browser shows the PetClient index page. Port 8090 is detected as open.
3. [for WebIDE users] One can run application from VSCode panel successfully without port conflict.
    <img width="525" alt="image" src="https://user-images.githubusercontent.com/3115235/161408519-f8adece8-0166-47a9-92d7-2350f2d9152b.png">
4. [for JB Gateway users] Connect to workspace using Gateway client, and can start the application from IDEA RunConfiguration successfully.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
